### PR TITLE
FOR_UPSTREAM [IOTG]: Fixes the VtsVndkOpenLibraries test failure issue

### DIFF
--- a/daemon/Android.mk
+++ b/daemon/Android.mk
@@ -61,7 +61,6 @@ LOCAL_SHARED_LIBRARIES := \
     libcrypto \
     libdrm \
     libssl \
-    libEGL \
     libhwcservice
 
 LOCAL_STATIC_LIBRARIES := \

--- a/daemon/display_window_util.h
+++ b/daemon/display_window_util.h
@@ -17,6 +17,8 @@
 #ifndef DISPLAY_WINDOW_UTIL_H
 #define DISPLAY_WINDOW_UTIL_H
 
+#ifndef ANDROID
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -46,5 +48,6 @@ bool                    util_set_content_protection(int crtc, int cp);
 }
 #endif /* __cplusplus */
 
+#endif /* ANDROID */
 
 #endif /* DISPLAY_WINDOW_UTIL_H */


### PR DESCRIPTION
Port the fix patch from Android/Master to Celadon
Change-Id: Ica5608c681a07a9755622ce3e978fb563ba44740
Tracked-On: OAM-86874
Signed-off-by: VenkataSainath Ravikanti <venkatasainath.ravikanti@intel.com>